### PR TITLE
Remove redundant version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a jsonified list of the cvarlist provided by scripting.elxdraco.net.
 I claim no copyrights, I am just using the data for my own project!
 
-The html version version of the list can be accessed [here](http://txdv.github.com/cstrike-cvarlist/)
+The html version of the list can be accessed [here](http://txdv.github.com/cstrike-cvarlist/)
 
 ## Contribution
 If you want to contribute, fork, modify data.json, for it is the version


### PR DESCRIPTION
Removing the redundant 'version' to keep README clean and concise